### PR TITLE
Accumulate uploaded chunk to local FS(or NFS) before sending to S3 Multipart

### DIFF
--- a/cmd/tusd/cli/composer.go
+++ b/cmd/tusd/cli/composer.go
@@ -31,10 +31,11 @@ func CreateComposer() {
 
 			s3Config = s3Config.WithEndpoint(Flags.S3Endpoint).WithS3ForcePathStyle(true)
 		}
+		stdout.Printf("Using S3 temporary part folder: %s\n", Flags.PartDir)
 
 		// Derive credentials from default credential chain (env, shared, ec2 instance role)
 		// as per https://github.com/aws/aws-sdk-go#configuring-credentials
-		store := s3store.New(Flags.S3Bucket, s3.New(session.Must(session.NewSession(&aws.Config{Region: aws.String(Flags.S3Region)})), s3Config))
+		store := s3store.New(Flags.S3Bucket, s3.New(session.Must(session.NewSession(&aws.Config{Region: aws.String(Flags.S3Region)})), s3Config), Flags.PartDir)
 		store.ObjectPrefix = Flags.S3ObjectPrefix
 		store.UseIn(Composer)
 

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -82,7 +82,6 @@ func ParseFlags() {
 			"more information on these options.")
 	}
 
-
 	if !strings.HasSuffix(Flags.PartDir, "/") {
 		Flags.PartDir+= "/"
 	}

--- a/cmd/tusd/cli/flags.go
+++ b/cmd/tusd/cli/flags.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"path/filepath"
+	"strings"
 )
 
 var Flags struct {
@@ -31,6 +32,7 @@ var Flags struct {
 	HttpHooksInstalled bool
 
 	AuthService		  string
+	PartDir           string
 }
 
 func ParseFlags() {
@@ -54,6 +56,7 @@ func ParseFlags() {
 	flag.StringVar(&Flags.MetricsPath, "metrics-path", "/metrics", "Path under which the metrics endpoint will be accessible")
 	flag.BoolVar(&Flags.BehindProxy, "behind-proxy", false, "Respect X-Forwarded-* and similar headers which may be set by proxies")
 	flag.StringVar(&Flags.AuthService, "auth-service", "", "Provide auth service hostname to authenticate all request. Set as empty or skip to bypass")
+	flag.StringVar(&Flags.PartDir, "part-path", "/mnt/efs", "Provide location for imcomplete S3 chunk parts")
 	flag.StringVar(&Flags.S3Region, "s3-region", "ap-southeast-1", "S3 region name. Default is ap-southeast-1")
 
 
@@ -77,5 +80,10 @@ func ParseFlags() {
 			"(using -s3-bucket) must be specified to start tusd but " +
 			"neither flag was provided. Please consult `tusd -help` for " +
 			"more information on these options.")
+	}
+
+
+	if !strings.HasSuffix(Flags.PartDir, "/") {
+		Flags.PartDir+= "/"
 	}
 }

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -271,7 +271,7 @@ func (store S3Store) WriteChunk(id string, offset int64, src io.Reader) (int64, 
 		return bytesUploaded, err
 	}
 	local_size=n+local_size
-    file.seek(0, 0)
+    file.Seek(0, 0)
 
 	targetS3Part := int64(size-offset)
 	if info.SizeIsDeferred || ((size-offset)>optimalPartSize) {
@@ -395,10 +395,10 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 	info.Offset = offset
 
 	// get under 5MB part from local FS here
-	if !info.SizeIsDeferred && (info.offset < info.Size) {
+	if !info.SizeIsDeferred && (info.Offset < info.Size) {
 		localSize, err := store.GetSubPartSize(uploadId)
 		if err!= nil {
-			return 0, err
+			return info, err
 		}
 		info.Offset += localSize
 	}

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -681,7 +681,7 @@ func (store S3Store) keyWithPrefix(key string) *string {
 }
 
 func (store S3Store) GetOrCreateSubPartFile(uploadId string) (f *os.File, size int64, err error) {
-	f, err =os.OpenFile(store.SubPartDir+uploadId+".subpart", os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_APPEND, 0600)
+	f, err =os.OpenFile(store.SubPartDir+uploadId+".subpart", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 
 	if err!= nil {
 		return f, 0, err

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -81,14 +81,11 @@ package s3store
 
 import (
 	"bytes"
-	"debug/elf"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -267,13 +267,14 @@ func (store S3Store) WriteChunk(id string, offset int64, src io.Reader) (int64, 
 	if err!=nil {
 		return bytesUploaded, err
 	}
-	local_size=n+local_size
+
     file.Seek(0, 0)
 
-	targetS3Part := int64(size-offset)
-	if info.SizeIsDeferred || ((size-offset)>optimalPartSize) {
+	targetS3Part := int64(size-offset+local_size)
+	if info.SizeIsDeferred || (targetS3Part>optimalPartSize) {
     	targetS3Part = optimalPartSize
 	}
+	local_size=n+local_size
 
 	if local_size >= targetS3Part {
 		defer os.Remove(file.Name())

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -297,56 +297,6 @@ func (store S3Store) WriteChunk(id string, offset int64, src io.Reader) (int64, 
 		bytesUploaded += n
 	}
 	return bytesUploaded, nil
-	/*
-	for {
-		// Create a temporary file to store the part in it
-		file, err := ioutil.TempFile("", "tusd-s3-tmp-")
-		if err != nil {
-			return bytesUploaded, err
-		}
-		defer os.Remove(file.Name())
-		defer file.Close()
-
-		limitedReader := io.LimitReader(src, optimalPartSize)
-		n, err := io.Copy(file, limitedReader)
-		// io.Copy does not return io.EOF, so we not have to handle it differently.
-		if err != nil {
-			return bytesUploaded, err
-		}
-		// If io.Copy is finished reading, it will always return (0, nil).
-		if n == 0 {
-			return bytesUploaded, nil
-		}
-
-		if !info.SizeIsDeferred {
-			if (size - offset) <= optimalPartSize {
-				if (size - offset) != n {
-					return bytesUploaded, nil
-				}
-			} else if n < optimalPartSize {
-				return bytesUploaded, nil
-			}
-		}
-
-		// Seek to the beginning of the file
-		file.Seek(0, 0)
-
-		_, err = store.Service.UploadPart(&s3.UploadPartInput{
-			Bucket:     aws.String(store.Bucket),
-			Key:        store.keyWithPrefix(uploadId),
-			UploadId:   aws.String(multipartId),
-			PartNumber: aws.Int64(nextPartNum),
-			Body:       file,
-		})
-		if err != nil {
-			return bytesUploaded, err
-		}
-
-		offset += n
-		bytesUploaded += n
-		nextPartNum += 1
-	}
-	*/
 }
 
 func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {

--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -163,6 +163,7 @@ func NewUnroutedHandler(config Config) (*UnroutedHandler, error) {
 
 func (handler *UnroutedHandler) authorizeClientRequest(token string) bool {
 
+	return true
 	if handler.AuthService == "" || handler.AuthService == "skip" {
 		handler.log("AuthAccessService", "bypass authentication", handler.AuthService)
 		return true

--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -163,7 +163,6 @@ func NewUnroutedHandler(config Config) (*UnroutedHandler, error) {
 
 func (handler *UnroutedHandler) authorizeClientRequest(token string) bool {
 
-	return true
 	if handler.AuthService == "" || handler.AuthService == "skip" {
 		handler.log("AuthAccessService", "bypass authentication", handler.AuthService)
 		return true


### PR DESCRIPTION
This to overcome current S3 Tusd implementation, where chunk size cannot be smaller than 5MB.

This improvement support following properties(tested using JS client):
-able to use any chunk size
-able to pause/resume upload
-able to change chunk size mid-upload
-able to recover the upload process, when local subpart file is missing/deleted (the progress will decrease momentarily and then continue forward). This property preserved to ensure robustness of overall system